### PR TITLE
Use UIImage drawing to correctly handle rotating images where imageOrientation != UIImageOrientationUp

### DIFF
--- a/Categories/UIImage+Resizing.m
+++ b/Categories/UIImage+Resizing.m
@@ -156,30 +156,18 @@
 	if (!bmContext)
 		return nil;
 
-	/// Handle orientation
-	if (UIImageOrientationLeft == self.imageOrientation)
-	{
-		CGContextRotateCTM(bmContext, M_PI_2);
-		CGContextTranslateCTM(bmContext, 0, -destHeight);
-	}
-	else if (UIImageOrientationRight == self.imageOrientation)
-	{
-		CGContextRotateCTM(bmContext, -M_PI_2);
-		CGContextTranslateCTM(bmContext, -destWidth, 0);
-	}
-	else if (UIImageOrientationDown == self.imageOrientation)
-	{
-		CGContextTranslateCTM(bmContext, destWidth, destHeight);
-		CGContextRotateCTM(bmContext, -M_PI);
-	}
-
 	/// Image quality
 	CGContextSetShouldAntialias(bmContext, true);
 	CGContextSetAllowsAntialiasing(bmContext, true);
 	CGContextSetInterpolationQuality(bmContext, kCGInterpolationHigh);
 
 	/// Draw the image in the bitmap context
-	CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = destWidth, .size.height = destHeight}, self.CGImage);
+
+    UIGraphicsPushContext(bmContext);
+    CGContextTranslateCTM(bmContext, 0, destHeight);
+    CGContextScaleCTM(bmContext, 1, -1);
+    [self drawInRect:CGRectMake(0.0, 0.0, destWidth, destHeight)];    
+    UIGraphicsPopContext();
 
 	/// Create an image object from the context
 	CGImageRef scaledImageRef = CGBitmapContextCreateImage(bmContext);


### PR DESCRIPTION
Images taken in portrait using the iPad's rear camera, then resized using [UIImage scaleToFitSize:] was producing an empty image. [UIImage drawInRect:] knows how to rotate images correctly when imageOrientation != UIImageOrientationUp, so let UIImage handle that. I made a test app using both methods, performance on the new iPad is identical when scaling 100 images.

Less code is better code :)
