### PR TITLE
Perserve original image scale & orientation when cropping

### DIFF
--- a/Categories/UIImage+Resizing.m
+++ b/Categories/UIImage+Resizing.m
@@ -59,9 +59,11 @@
 			break;
 	}
 
+    CGRect cropRect = CGRectMake(x * self.scale, y * self.scale, newSize.width * self.scale, newSize.height * self.scale);
+    
 	/// Create the cropped image
-	CGImageRef croppedImageRef = CGImageCreateWithImageInRect(self.CGImage, (CGRect){.origin.x = x, .origin.y = y, .size = newSize});
-	UIImage* cropped = [UIImage imageWithCGImage:croppedImageRef];
+	CGImageRef croppedImageRef = CGImageCreateWithImageInRect(self.CGImage, cropRect);
+	UIImage* cropped = [UIImage imageWithCGImage:croppedImageRef scale:self.scale orientation:self.imageOrientation];
 
 	/// Cleanup
 	CGImageRelease(croppedImageRef);


### PR DESCRIPTION
CGImage has no concept of scale or orientation. Scale our cropping rect appropriately & pass our scale / orientation information to the new UIImage.
