### PR TITLE
Fixed UIImage+Rotating for Retina images.

### DIFF
--- a/Categories/UIImage+Rotating.m
+++ b/Categories/UIImage+Rotating.m
@@ -17,8 +17,8 @@
 
 -(UIImage*)rotateInRadians:(float)radians
 {
-	const size_t width = self.size.width;
-	const size_t height = self.size.height;
+	const size_t width = self.size.width * self.scale;
+	const size_t height = self.size.height * self.scale;
 
 	CGRect imgRect = (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = width, .size.height = height};
 	CGRect rotatedRect = CGRectApplyAffineTransform(imgRect, CGAffineTransformMakeRotation(radians));
@@ -41,7 +41,7 @@
 
 	/// Create an image object from the context
 	CGImageRef rotatedImageRef = CGBitmapContextCreateImage(bmContext);
-	UIImage* rotated = [UIImage imageWithCGImage:rotatedImageRef];
+	UIImage* rotated = [UIImage imageWithCGImage:rotatedImageRef scale:self.scale orientation:self.imageOrientation];
 
 	/// Cleanup
 	CGImageRelease(rotatedImageRef);
@@ -61,8 +61,8 @@
 		return nil;
 
 	/// Create an ARGB bitmap context
-	const size_t width = self.size.width;
-	const size_t height = self.size.height;
+	const size_t width = self.size.width * self.scale;
+	const size_t height = self.size.height * self.scale;
 	const size_t bytesPerRow = width * kNyxNumberOfComponentsPerARBGPixel;
 	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow);
 	if (!bmContext) 
@@ -85,7 +85,7 @@
 	vImageRotate_ARGB8888(&src, &dest, NULL, radians, bgColor, kvImageBackgroundColorFill);
 	
 	CGImageRef rotatedImageRef = CGBitmapContextCreateImage(bmContext);
-	UIImage* rotated = [UIImage imageWithCGImage:rotatedImageRef];
+	UIImage* rotated = [UIImage imageWithCGImage:rotatedImageRef scale:self.scale orientation:self.imageOrientation];
 	
 	/// Cleanup
 	CGImageRelease(rotatedImageRef);
@@ -102,8 +102,8 @@
 -(UIImage*)verticalFlip
 {
 	/// Create an ARGB bitmap context
-	const size_t originalWidth = self.size.width;
-	const size_t originalHeight = self.size.height;
+	const size_t originalWidth = self.size.width * self.scale;
+	const size_t originalHeight = self.size.height * self.scale;
 	CGContextRef bmContext = NYXCreateARGBBitmapContext(originalWidth, originalHeight, originalWidth * kNyxNumberOfComponentsPerARBGPixel);
 	if (!bmContext)
 		return nil;
@@ -121,7 +121,7 @@
 	
 	/// Create an image object from the context
 	CGImageRef flippedImageRef = CGBitmapContextCreateImage(bmContext);
-	UIImage* flipped = [UIImage imageWithCGImage:flippedImageRef];
+	UIImage* flipped = [UIImage imageWithCGImage:flippedImageRef scale:self.scale orientation:self.imageOrientation];
 	
 	/// Cleanup
 	CGImageRelease(flippedImageRef);
@@ -133,8 +133,8 @@
 -(UIImage*)horizontalFlip
 {
 	/// Create an ARGB bitmap context
-	const size_t originalWidth = self.size.width;
-	const size_t originalHeight = self.size.height;
+	const size_t originalWidth = self.size.width * self.scale;
+	const size_t originalHeight = self.size.height * self.scale;
 	CGContextRef bmContext = NYXCreateARGBBitmapContext(originalWidth, originalHeight, originalWidth * kNyxNumberOfComponentsPerARBGPixel);
 	if (!bmContext)
 		return nil;
@@ -152,7 +152,7 @@
 	
 	/// Create an image object from the context
 	CGImageRef flippedImageRef = CGBitmapContextCreateImage(bmContext);
-	UIImage* flipped = [UIImage imageWithCGImage:flippedImageRef];
+	UIImage* flipped = [UIImage imageWithCGImage:flippedImageRef scale:self.scale orientation:self.imageOrientation];
 	
 	/// Cleanup
 	CGImageRelease(flippedImageRef);


### PR DESCRIPTION
self.scale was not taken into account, therefore Retina images became non-Retina when rotated. This is now fixed.
