### PR TITLE
Fixed issue with image masking and retina displays

### DIFF
--- a/Categories/UIImage+Masking.m
+++ b/Categories/UIImage+Masking.m
@@ -16,8 +16,8 @@
 -(UIImage*)maskWithImage:(UIImage*)maskImage
 {
 	/// Create a bitmap context with valid alpha
-	const size_t originalWidth = (size_t)self.size.width;
-	const size_t originalHeight = (size_t)self.size.height;
+	const size_t originalWidth = (size_t)self.size.width * self.scale;
+	const size_t originalHeight = (size_t)self.size.height * self.scale;
 	CGContextRef bmContext = NYXCreateARGBBitmapContext(originalWidth, originalHeight, 0);
 	if (!bmContext)
 		return nil;
@@ -41,7 +41,7 @@
 	/// Apply the mask
 	CGImageRef maskedImageRef = CGImageCreateWithMask(imageRefWithAlpha, mask);
 
-	UIImage* result = [UIImage imageWithCGImage:maskedImageRef];
+	UIImage* result = [UIImage imageWithCGImage:maskedImageRef scale:self.scale orientation:self.imageOrientation];
 
 	/// Cleanup
 	CGImageRelease(maskedImageRef);


### PR DESCRIPTION
Funny thing about this issue, is that it only arises when using asynchronous image loading,...at least for me

I came across the issue when using UIImageView+AFNetworking category which very popular in conjunction with this category to set the image.

hope this helps
