### PR TITLE
Add #import <UIKit/UIKit.h>

### DIFF
--- a/Helper/NYXImagesKit.h
+++ b/Helper/NYXImagesKit.h
@@ -7,6 +7,7 @@
 //  www.cocoaintheshell.com
 //
 
+#import <UIKit/UIKit.h>
 
 #import "UIImage+Blurring.h"
 #import "UIImage+Enhancing.h"


### PR DESCRIPTION
I'm using NYXImagesKit with RubyMotion & CocoaPods.

Without this #import, generated Pods.bridgesupport file won't include UIImage category methods.
