### PR TITLE
x coordinate for NYXCropModeBottomCenter is not correct

### DIFF
--- a/Categories/UIImage+Resizing.m
+++ b/Categories/UIImage+Resizing.m
@@ -35,7 +35,7 @@
 			y = size.height - newSize.height;
 			break;
 		case NYXCropModeBottomCenter:
-			x = newSize.width * 0.5f;
+			x = (size.width - newSize.width) * 0.5f;
 			y = size.height - newSize.height;
 			break;
 		case NYXCropModeBottomRight:


### PR DESCRIPTION
I've fixed an issue con the cropToSize:usingMode: method that was calculating the wrong x coordinate for the NYXCropModeBottomCenter cropping mode
