### PR TITLE
preserving orientation problem in scaleByFactor: method

### DIFF
--- a/Categories/UIImage+Resizing.h
+++ b/Categories/UIImage+Resizing.h
@@ -29,10 +29,18 @@ typedef enum
 
 -(UIImage*)cropToSize:(CGSize)newSize usingMode:(NYXCropMode)cropMode;
 
+// NYXCropModeTopLeft crop mode used
 -(UIImage*)cropToSize:(CGSize)newSize;
 
 -(UIImage*)scaleByFactor:(float)scaleFactor;
 
+// Same as 'scale to fill' in IB.
+-(UIImage*)scaleToFillSize:(CGSize)newSize;
+
+// Preserves aspect ratio. Same as 'aspect fit' in IB.
 -(UIImage*)scaleToFitSize:(CGSize)newSize;
+
+// Preserves aspect ratio. Same as 'aspect fill' in IB.
+-(UIImage*)scaleToCoverSize:(CGSize)newSize;
 
 @end


### PR DESCRIPTION
My previous pull request (#19 issue) added a problem in the resizing code. Orientation should not be preserved if orientation handling code (92-107 lines) is executed. My suggestion is just to preserve initial orientation, not to rotate the image.
- IB like 'aspect fill' and 'scale to fit' methods
  They don't take orientation into account, user is responsible for it
- little refactor
  CG work is done only in scaleToFillSize: method, all other methods use scaleToFillSize:
