### PR TITLE
If original image had no alpha channel, modified image won't either

### DIFF
--- a/Categories/UIImage+Blurring.m
+++ b/Categories/UIImage+Blurring.m
@@ -29,7 +29,7 @@ static int16_t __s_gaussianblur_kernel_5x5[25] = {
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
 	const size_t bytesPerRow = width * kNyxNumberOfComponentsPerARBGPixel;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 

--- a/Categories/UIImage+Filtering.m
+++ b/Categories/UIImage+Filtering.m
@@ -74,7 +74,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	/// Create an ARGB bitmap context
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 
@@ -128,7 +128,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	/// Create an ARGB bitmap context
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 
@@ -195,7 +195,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
 	const size_t bytesPerRow = width * kNyxNumberOfComponentsPerARBGPixel;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 
@@ -283,7 +283,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
 	const size_t bytesPerRow = width * kNyxNumberOfComponentsPerARBGPixel;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 
@@ -327,7 +327,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	const size_t bytesPerRow = width * kNyxNumberOfComponentsPerARBGPixel;
 
 	/// Create an ARGB bitmap context
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 
@@ -429,7 +429,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	/// Create an ARGB bitmap context
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 
@@ -489,7 +489,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	/// Create an ARGB bitmap context
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel, YES);
 	if (!bmContext) 
 		return nil;
 
@@ -526,7 +526,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 		/// Create an ARGB bitmap context
 		const size_t width = (size_t)self.size.width;
 		const size_t height = (size_t)self.size.height;
-		CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel);
+		CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, width * kNyxNumberOfComponentsPerARBGPixel, NYXImageHasAlpha(self.CGImage));
 		if (!bmContext) 
 			return nil;
 
@@ -605,7 +605,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
 	const size_t bytesPerRow = width * kNyxNumberOfComponentsPerARBGPixel;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 
@@ -646,7 +646,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
 	const size_t width = (size_t)self.size.width;
 	const size_t height = (size_t)self.size.height;
 	const size_t bytesPerRow = width * kNyxNumberOfComponentsPerARBGPixel;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext) 
 		return nil;
 

--- a/Categories/UIImage+Masking.m
+++ b/Categories/UIImage+Masking.m
@@ -18,7 +18,7 @@
 	/// Create a bitmap context with valid alpha
 	const size_t originalWidth = (size_t)(self.size.width * self.scale);
 	const size_t originalHeight = (size_t)(self.size.height * self.scale);
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(originalWidth, originalHeight, 0);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(originalWidth, originalHeight, 0, YES);
 	if (!bmContext)
 		return nil;
 

--- a/Categories/UIImage+Resizing.m
+++ b/Categories/UIImage+Resizing.m
@@ -98,7 +98,7 @@
 	}
 
   /// Create an ARGB bitmap context
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(destWidth, destHeight, destWidth * kNyxNumberOfComponentsPerARBGPixel);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(destWidth, destHeight, destWidth * kNyxNumberOfComponentsPerARBGPixel, NYXImageHasAlpha(self.CGImage));
 	if (!bmContext)
 		return nil;
 

--- a/Categories/UIImage+Rotating.m
+++ b/Categories/UIImage+Rotating.m
@@ -22,7 +22,7 @@
 
 	CGRect rotatedRect = CGRectApplyAffineTransform(CGRectMake(0., 0., width, height), CGAffineTransformMakeRotation(radians));
 
-	CGContextRef bmContext = NYXCreateARGBBitmapContext((size_t)rotatedRect.size.width, (size_t)rotatedRect.size.height, (size_t)rotatedRect.size.width * kNyxNumberOfComponentsPerARBGPixel);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext((size_t)rotatedRect.size.width, (size_t)rotatedRect.size.height, (size_t)rotatedRect.size.width * kNyxNumberOfComponentsPerARBGPixel, YES);
 	if (!bmContext)
 		return nil;
 
@@ -79,7 +79,7 @@
 	const size_t width = (size_t)(self.size.width * self.scale);
 	const size_t height = (size_t)(self.size.height * self.scale);
 	const size_t bytesPerRow = width * kNyxNumberOfComponentsPerARBGPixel;
-	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext(width, height, bytesPerRow, YES);
 	if (!bmContext)
 		return nil;
 

--- a/Classes/NYXProgressiveImageView.m
+++ b/Classes/NYXProgressiveImageView.m
@@ -333,7 +333,7 @@ typedef struct
 -(CGImageRef)createTransitoryImage:(CGImageRef)partialImage
 {
 	const size_t partialHeight = CGImageGetHeight(partialImage);
-	CGContextRef bmContext = NYXCreateARGBBitmapContext((size_t)_imageWidth, (size_t)_imageHeight, (size_t)_imageWidth * 4);
+	CGContextRef bmContext = NYXCreateARGBBitmapContext((size_t)_imageWidth, (size_t)_imageHeight, (size_t)_imageWidth * 4, NYXImageHasAlpha(partialImage));
 	if (!bmContext)
 		return NULL;
 	CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = _imageWidth, .size.height = partialHeight}, partialImage);

--- a/Helper/NYXImagesHelper.h
+++ b/Helper/NYXImagesHelper.h
@@ -40,8 +40,9 @@
 	#define NYX_DISPATCH_RELEASE(__QUEUE) (dispatch_release(__QUEUE))
 #endif
 
-CGContextRef NYXCreateARGBBitmapContext(const size_t width, const size_t height, const size_t bytesPerRow);
+CGContextRef NYXCreateARGBBitmapContext(const size_t width, const size_t height, const size_t bytesPerRow, BOOL withAlpha);
 CGImageRef NYXCreateGradientImage(const size_t pixelsWide, const size_t pixelsHigh, const CGFloat fromAlpha, const CGFloat toAlpha);
 CIContext* NYXGetCIContext(void);
 CGColorSpaceRef NYXGetRGBColorSpace(void);
 void NYXImagesKitRelease(void);
+BOOL NYXImageHasAlpha(CGImageRef imageRef);

--- a/Helper/NYXImagesHelper.m
+++ b/Helper/NYXImagesHelper.m
@@ -16,12 +16,13 @@ static CIContext* __ciContext = nil;
 static CGColorSpaceRef __rgbColorSpace = NULL;
 
 
-CGContextRef NYXCreateARGBBitmapContext(const size_t width, const size_t height, const size_t bytesPerRow)
+CGContextRef NYXCreateARGBBitmapContext(const size_t width, const size_t height, const size_t bytesPerRow, BOOL withAlpha)
 {
 	/// Use the generic RGB color space
 	/// We avoid the NULL check because CGColorSpaceRelease() NULL check the value anyway, and worst case scenario = fail to create context
 	/// Create the bitmap context, we want pre-multiplied ARGB, 8-bits per component
-	CGContextRef bmContext = CGBitmapContextCreate(NULL, width, height, 8/*Bits per component*/, bytesPerRow, NYXGetRGBColorSpace(), kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
+	CGImageAlphaInfo alphaInfo = (withAlpha ? kCGImageAlphaPremultipliedFirst : kCGImageAlphaNoneSkipFirst);
+	CGContextRef bmContext = CGBitmapContextCreate(NULL, width, height, 8/*Bits per component*/, bytesPerRow, NYXGetRGBColorSpace(), kCGBitmapByteOrderDefault | alphaInfo);
 
 	return bmContext;
 }
@@ -87,4 +88,12 @@ void NYXImagesKitRelease(void)
 		CGColorSpaceRelease(__rgbColorSpace), __rgbColorSpace = NULL;
 	if (__ciContext)
 		__ciContext = nil;
+}
+
+BOOL NYXImageHasAlpha(CGImageRef imageRef)
+{
+	CGImageAlphaInfo alpha = CGImageGetAlphaInfo(imageRef);
+	BOOL hasAlpha = (alpha == kCGImageAlphaFirst || alpha == kCGImageAlphaLast || alpha == kCGImageAlphaPremultipliedFirst || alpha == kCGImageAlphaPremultipliedLast);
+
+	return hasAlpha;
 }


### PR DESCRIPTION
(exception in the cases where the modification requires an alpha channel)

I need to know if an image (after scale/crop) has an alpha channel to know if I can safely save it as JPEG (my images are mostly photos).

This modification keep opaque images opaque.
