### PR TITLE
more coherent resize methods

### DIFF
--- a/Categories/UIImage+Resizing.h
+++ b/Categories/UIImage+Resizing.h
@@ -24,6 +24,13 @@ typedef enum
 	NYXCropModeCenter
 } NYXCropMode;
 
+typedef enum
+{
+	NYXResizeModeScaleToFill,
+	NYXResizeModeAspectFit,
+	NYXResizeModeAspectFill
+} NYXResizeMode;
+
 
 @interface UIImage (NYX_Resizing)
 
@@ -33,6 +40,11 @@ typedef enum
 -(UIImage*)cropToSize:(CGSize)newSize;
 
 -(UIImage*)scaleByFactor:(float)scaleFactor;
+
+-(UIImage*)scaleToSize:(CGSize)newSize usingMode:(NYXResizeMode)resizeMode;
+
+// NYXResizeModeScaleToFill resize mode used
+-(UIImage*)scaleToSize:(CGSize)newSize;
 
 // Same as 'scale to fill' in IB.
 -(UIImage*)scaleToFillSize:(CGSize)newSize;

--- a/Categories/UIImage+Resizing.m
+++ b/Categories/UIImage+Resizing.m
@@ -83,6 +83,25 @@
 	return [self scaleToFillSize:scaledSize];
 }
 
+-(UIImage*)scaleToSize:(CGSize)newSize usingMode:(NYXResizeMode)resizeMode
+{
+	switch (resizeMode)
+	{
+		case NYXResizeModeAspectFit:
+			return [self scaleToFitSize:newSize];
+		case NYXResizeModeAspectFill:
+			return [self scaleToCoverSize:newSize];
+		default:
+			return [self scaleToFillSize:newSize];
+	}
+}
+
+/* Convenience method to scale the image using the NYXResizeModeScaleToFill mode */
+-(UIImage*)scaleToSize:(CGSize)newSize
+{
+	return [self scaleToFillSize:newSize];
+}
+
 -(UIImage*)scaleToFillSize:(CGSize)newSize
 {
 	size_t destWidth = (size_t)(newSize.width * self.scale);


### PR DESCRIPTION
Created new resize methods to mimic the crop methods. I believe that using the resize mode enum will be clearer to users of the library.
