### PR TITLE
Preserving alpha channel after grayscale

### DIFF
--- a/Categories/UIImage+Filtering.m
+++ b/Categories/UIImage+Filtering.m
@@ -418,6 +418,7 @@ static int16_t __s_unsharpen_kernel_3x3[9] = {
     
     // Preserve alpha channel by creating context with 'alpha only' values
     // and using it as a mask for previously generated `grayscaledImageRef`
+    // based on: http://incurlybraces.com/convert-transparent-image-to-grayscale-in-ios.html
     bmContext = CGBitmapContextCreate(nil, width, height, 8, width, nil, (CGBitmapInfo) kCGImageAlphaOnly);
     CGContextDrawImage(bmContext, imageRect, [self CGImage]);
     CGImageRef mask = CGBitmapContextCreateImage(bmContext);


### PR DESCRIPTION
I extended `grayscale()` method so it preserves alpha channel after making image gray. Solution is based on [this blog post](http://incurlybraces.com/convert-transparent-image-to-grayscale-in-ios.html).
The thing is to create new context with `kCGImageAlphaOnly` flag that will gather only translucent pixels from original image (at this point grayscaled image is already broken - it has black pixels where translucent were present). This new context is used as a mask in `CGImageCreateWithMask` function together with grayscaled image to preserver only those pixels which were not translucent in the original image.

Example image without my modification:
![ios simulator screen shot 15 paz 2014 15 14 29](https://cloud.githubusercontent.com/assets/1155763/4645905/6eef4a0e-546e-11e4-8054-d1a349ac65dd.png)

Image after this modification:
![ios simulator screen shot 15 paz 2014 15 14 11](https://cloud.githubusercontent.com/assets/1155763/4645914/792d895e-546e-11e4-91e9-fff6f3a32518.png)
