### PR TITLE
In cropToSize when image orientation is taken into account, width and…

### DIFF
--- a/Categories/UIImage+Resizing.m
+++ b/Categories/UIImage+Resizing.m
@@ -64,6 +64,10 @@
 		CGFloat temp = x;
 		x = y;
 		y = temp;
+        
+        temp = newSize.width;
+        newSize.width = newSize.height;
+        newSize.height = temp;
 	}
 
 	CGRect cropRect = CGRectMake(x * self.scale, y * self.scale, newSize.width * self.scale, newSize.height * self.scale);


### PR DESCRIPTION
… height should be also switched places - otherwise the image is not cropped correctly.

As an example, imagine a very long and narrow image. When cropping, from the coordinates perspective the image is a wide panoramic image. We switch x with y but also the height now becomes width, which was missing from the code.  

